### PR TITLE
Added experimental support for individual XPDR digits.

### DIFF
--- a/FenixQuartz/MainWindow.xaml
+++ b/FenixQuartz/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:FenixQuartz"
         mc:Ignorable="d"
-        Title="Debug UI" Height="564" Width="432" IsVisibleChanged="Window_IsVisibleChanged" Closing="Window_Closing">
+        Title="Debug UI" Height="626" Width="432" IsVisibleChanged="Window_IsVisibleChanged" Closing="Window_Closing">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition></ColumnDefinition>
@@ -119,6 +119,17 @@
                 <Label Name="xpdrInput"></Label>
             </StackPanel>
             <StackPanel Orientation="Horizontal">
+                <Label>xpdrDigitCount</Label>
+                <Label Name="xpdrDigitCount"></Label>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <Label>xpdrDigits</Label>
+                <Label BorderThickness="1" BorderBrush="DarkGray" Width="30" Name="xpdrDigit1"></Label>
+                <Label BorderThickness="1" BorderBrush="DarkGray" Width="30" Name="xpdrDigit2"></Label>
+                <Label BorderThickness="1" BorderBrush="DarkGray" Width="30" Name="xpdrDigit3"></Label>
+                <Label BorderThickness="1" BorderBrush="DarkGray" Width="30" Name="xpdrDigit4"></Label>
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">   
                 <Label>bat1Display</Label>
                 <Label Name="bat1Display"></Label>
             </StackPanel>

--- a/FenixQuartz/MainWindow.xaml.cs
+++ b/FenixQuartz/MainWindow.xaml.cs
@@ -97,6 +97,12 @@ namespace FenixQuartz
                 speedVAPP_3.Content = values["speedVAPP-3"].GetValue() ?? 0;
                 speedVAPP_4.Content = values["speedVAPP-4"].GetValue() ?? 0;
                 speedVAPP_5.Content = values["speedVAPP-5"].GetValue() ?? 0;
+
+                xpdrDigitCount.Content = values["xpdrDigitCount"].GetValue() ?? -1;
+                xpdrDigit1.Content = manager.xpdrDigit1;
+                xpdrDigit2.Content = manager.xpdrDigit2;
+                xpdrDigit3.Content = manager.xpdrDigit3;
+                xpdrDigit4.Content = manager.xpdrDigit4;                
             }
         }
 

--- a/FenixQuartz/MemoryValue.cs
+++ b/FenixQuartz/MemoryValue.cs
@@ -78,13 +78,15 @@ namespace FenixQuartz
                     return BitConverter.ToSingle(valueBuffer, 0);
                 else if (TypeName == "double" && !CastInteger)
                     return BitConverter.ToDouble(valueBuffer, 0);
-                else if (TypeName == "bool" || TypeName == "int" && Size == 1)
+                else if (TypeName == "bool")
                     return BitConverter.ToBoolean(valueBuffer, 0);
                 else if (TypeName == "int")
                     if (Size == 4)
                         return BitConverter.ToInt32(valueBuffer, 0);
-                    else //if (Size == 2)
+                    else if (Size == 2)
                         return BitConverter.ToInt16(valueBuffer, 0);
+                    else
+                        return valueBuffer[0];
                 else if (TypeName == "long")
                     return BitConverter.ToInt64(valueBuffer, 0);
                 else // == string

--- a/FenixQuartz/OutputDefinitions.cs
+++ b/FenixQuartz/OutputDefinitions.cs
@@ -131,6 +131,13 @@ namespace FenixQuartz
                 //CHR + ET
                 definitions.Add(AddIpcOffset("clockChr", "int", 4, ref nextOffset));
                 definitions.Add(AddIpcOffset("clockEt", "int", 4, ref nextOffset));
+
+
+                definitions.Add(AddIpcOffset("xpdrDigitCount", "byte", 1, ref nextOffset));
+                definitions.Add(AddIpcOffset("xpdrDigit1", "byte", 1, ref nextOffset));
+                definitions.Add(AddIpcOffset("xpdrDigit2", "byte", 1, ref nextOffset));
+                definitions.Add(AddIpcOffset("xpdrDigit3", "byte", 1, ref nextOffset));
+                definitions.Add(AddIpcOffset("xpdrDigit4", "byte", 1, ref nextOffset));
             }
             //// RAW VALUES (L-Var)
             else
@@ -177,6 +184,12 @@ namespace FenixQuartz
                 //CHR + ET
                 definitions.Add(new OutputDefinition("clockChr"));
                 definitions.Add(new OutputDefinition("clockEt"));
+
+                definitions.Add(new OutputDefinition("xpdrDigitCount"));
+                definitions.Add(new OutputDefinition("xpdrDigit1"));
+                definitions.Add(new OutputDefinition("xpdrDigit2"));
+                definitions.Add(new OutputDefinition("xpdrDigit3"));
+                definitions.Add(new OutputDefinition("xpdrDigit4"));
             }
 
 


### PR DESCRIPTION
Added the definitions:

* `xpdrDigitCount` - The number of digits currently displayed in the transponder display.
* `xpdrDigit1` - The first digit in the display.
* `xpdrDigit2` - The second digit in the display.
* `xpdrDigit3` - The third digit in the display.
* `xpdrDigit4` - The fourth digit in the display.

(These are only presented when using raw values, eg. IPC or LVar).

Fixes #18

**Note** I am very inexperienced in this memory value finding business. I stumbled upon this offset/value, and referenced it relative to one of the search values you already provided. It works on my machine in version 1.5.2.214, but I really have no idea if this works everywhere, or for anyone else really.